### PR TITLE
support hyperref links in rotated copyright notice

### DIFF
--- a/copyrightbox.sty
+++ b/copyrightbox.sty
@@ -56,14 +56,14 @@
 \CRB@ydiff{ciimage.south}{ciimage.north}
 \CRB@xdiff{ciimage.west}{ciimage.east}
 \ifthenelse{\equal{#1}{r}}{%
-\node[inner sep=0pt,right=1ex of ciimage.south east,anchor=north west,rotate=90]%
-{\raggedleft\parbox{\the\CRB@ydiffl}{\CRB@setcopyrightparagraphstyle{}#3}};%
+\node[inner sep=0pt,right=1ex of ciimage.south east,above right]%
+{\rotatebox{90}{\raggedleft\parbox{\the\CRB@ydiffl}{\CRB@setcopyrightparagraphstyle{}#3}}};%
 }{%
 \ifthenelse{\equal{#1}{l}}{%
-\node[inner sep=2ex,right=1ex of ciimage.south west,anchor=south west,rotate=90]
+\node[inner sep=2ex,right=1ex of ciimage.south west,above left]
 % Separation needed to be 2ex otherwise letters like j would
 % cross into the image
-{\raggedleft\parbox{\the\CRB@ydiffl}{\CRB@setcopyrightparagraphstyle{}#3}};%
+{\rotatebox{90}{\raggedleft\parbox{\the\CRB@ydiffl}{\CRB@setcopyrightparagraphstyle{}#3}}};%
 }{%
 \node[inner sep=0pt,below=1ex of ciimage.south west,anchor=north west]%
 {\raggedleft\parbox{\the\CRB@xdiffl}{\CRB@setcopyrightparagraphstyle{}#3}};%


### PR DESCRIPTION
If you put a URL inside the copyright notice then with the current version if you use the hyperref package the clickable area isn't rotated to match the position of the URL. This changes moves the rotate from being a parameter of the node to using a `\rotatebox` which ensures that the hyperref link is properly rotated to match.